### PR TITLE
Prevent creation of instances with same tablename.

### DIFF
--- a/server/methods.js
+++ b/server/methods.js
@@ -107,6 +107,11 @@ Meteor.methods({
 		if(!Meteor.user()) {
 			return false;
 		}
+
+		if(Instances.find({ tablename: tablename }).count() > 0) {
+			return false;
+		}
+
 		var keys;
 		if(mods.length > 4) {
 			var errors = [


### PR DESCRIPTION
Fix for Bug #12670 will check to see if the tablename already exists before creating an instance with the same tablename.