### PR TITLE
Delay refresh

### DIFF
--- a/client/views/footer/footer.html
+++ b/client/views/footer/footer.html
@@ -1,5 +1,12 @@
 <template name="footer">
 	<div id="footercontainer">
-		<p id="footercredits"><span id="creditsbutton">Credits</span> // <a id="codebutton" href="https://github.com/berkmancenter/question_tool" target="_blank">Code</a></p>
+		<p id="footercredits"><span id="creditsbutton">Credits</span> // <a id="codebutton" href="https://github.com/berkmancenter/question_tool" target="_blank">Code</a> // 		
+		Refresh every: 
+			<select id="refersh">
+				<option value="30000">30 seconds</option>
+				<option value="60000">60 seconds</option>
+				<option value="120000">2 minutes</option>
+				<option value="240000">4 minutes</option>
+			</select></p>
 	</div>
 </template>

--- a/client/views/footer/footer.js
+++ b/client/views/footer/footer.js
@@ -2,5 +2,12 @@ Template.footer.events({
 	"click #creditsbutton": function(event, template) {
 		var parentNode = document.getElementById("banner");
 		popoverTemplate = Blaze.render(Template.credits, parentNode);
+	},
+	"change select": function(evt) {
+	  reconnect_interval = $(evt.target).val();
+	  Meteor.clearInterval(reconnect);
+	  reconnect = Meteor.setInterval( function () { 
+	  	Meteor.reconnect();
+	  }, reconnect_interval );
 	}
 });

--- a/client/views/list/list.js
+++ b/client/views/list/list.js
@@ -6,13 +6,10 @@ Meteor.setInterval( function () {
 reconnect_interval = 30000;
 reconnect = Meteor.setInterval( function () { 
 	Meteor.reconnect(); 
-	console.log("Reconnected");
-	console.log(reconnect_interval);
 }, reconnect_interval );
 
 disconnect = Meteor.setInterval( function () { 
 	Meteor.disconnect();
-	console.log("Disconnected");
 }, Session.get("disconnect_interval") );
 
 Template.list.onCreated(function () {
@@ -473,7 +470,6 @@ Template.list.events({
 		});
 		setTimeout(function() { 
 			Meteor.disconnect();
-			console.log("Correctly disconnected!")
 		}, 1500);
 	},
 	"keypress .replyemail": function(event, template) {

--- a/client/views/list/list.js
+++ b/client/views/list/list.js
@@ -3,6 +3,18 @@ Meteor.setInterval( function () {
 	Session.set("timeval", new Date().getTime());
 }, 1000);
 
+reconnect_interval = 30000;
+reconnect = Meteor.setInterval( function () { 
+	Meteor.reconnect(); 
+	console.log("Reconnected");
+	console.log(reconnect_interval);
+}, reconnect_interval );
+
+disconnect = Meteor.setInterval( function () { 
+	Meteor.disconnect();
+	console.log("Disconnected");
+}, Session.get("disconnect_interval") );
+
 Template.list.onCreated(function () {
 	Session.set("responseName", "");
 	Session.set("responseEmail", "");
@@ -35,6 +47,7 @@ Template.list.onCreated(function () {
 	}
 	Session.set("stale_length",  Template.instance().data.stale_length);
 	Session.set("new_length",  Template.instance().data.new_length);
+	Session.set("disconnect_interval", 11000);
 });
 
 Template.list.onRendered(function() {
@@ -280,6 +293,7 @@ Template.list.helpers({
 Template.list.events({
 	// When the vote button is clicked...
 	"click .voteright": function(event, template) {
+		Meteor.reconnect();
 		// Retrieves the user's IP address from the server
 		Meteor.call('getIP', function (error, result) {
 			var ip = result;
@@ -302,6 +316,9 @@ Template.list.events({
 				});
 			}
 		});
+		setTimeout(function() { 
+			Meteor.disconnect();
+		}, 1500);
 	},
 	// When the admin hide button is clicked...
 	"click .adminquestionhide": function(event, template) {	
@@ -391,6 +408,7 @@ Template.list.events({
 		}
 	},
 	"click .replybottombutton": function(event, template) {
+		Meteor.reconnect();
 		// Retrieves data from form
 		var theID = event.target.id;
 		//var anonymous = document.getElementById("anonbox").checked;
@@ -453,6 +471,10 @@ Template.list.events({
 				});
 			}
 		});
+		setTimeout(function() { 
+			Meteor.disconnect();
+			console.log("Correctly disconnected!")
+		}, 1500);
 	},
 	"keypress .replyemail": function(event, template) {
 		event.which = event.which || event.keyCode;

--- a/client/views/propose/propose.js
+++ b/client/views/propose/propose.js
@@ -98,6 +98,7 @@ Template.propose.events({
 		}
 	},
 	"click #buttonarea": function(event, template) {
+		Meteor.reconnect();
 		// Retrieves data from the form
 		var question = document.getElementById("questioninput").value;
 		question = $("<p>").html(question).text();
@@ -227,6 +228,9 @@ Template.propose.events({
 				});
 			}
 		});
+		setTimeout(function() { 
+			Meteor.disconnect();
+		}, 1500);
 	},
 	"keyup #questioninput": function(event, template) {
 		var urlRegex = /(https?:\/\/(?:www\.|(?!www))[^\s\.]+\.[^\s]{2,}|www\.[^\s]+\.[^\s]{2,})/g;


### PR DESCRIPTION
This adds a delay to question list refreshes. It does so by disconnecting
Meteor from its server and then reconnecting at a specified interval like
a heartbeat. Question Tool will also reconnect to the server for
necessary actions like replying to a question or asking a new question.
