### PR TITLE
Fix route duplication error

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -16,3 +16,4 @@ meteorhacks:fast-render
 todda00:friendly-slugs
 vazco:universe-html-purifier
 percolate:synced-cron
+iron:middleware-stack@1.1.0

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -23,13 +23,13 @@ htmljs@1.0.4
 http@1.1.0
 id-map@1.0.3
 iron:controller@1.0.8
-iron:core@1.0.8
+iron:core@1.0.11
 iron:dynamic-template@1.0.8
 iron:layout@1.0.8
 iron:location@1.0.9
-iron:middleware-stack@1.0.9
+iron:middleware-stack@1.1.0
 iron:router@1.0.9
-iron:url@1.0.9
+iron:url@1.0.11
 jquery@1.11.3_2
 json@1.0.3
 launch-screen@1.0.2


### PR DESCRIPTION
While using Chrome 51, console shows error that;

```
Uncaught Error: Handler with name 'route' already exists.
```

and this (https://github.com/iron-meteor/iron-router/issues/1513) also confirms that it also occurs in Chrome 50+. Updating `iron:middleware-stack` to 1.1.0 fixes the issue.
