### PR TITLE
Fix favorite button not working

### DIFF
--- a/client/views/helpers/chunks/instance_div/instance_div.scss
+++ b/client/views/helpers/chunks/instance_div/instance_div.scss
@@ -35,6 +35,7 @@
 	height: 18px;
 	cursor: pointer;
 	z-index: 20;
+	position: relative;
 }
 
 .instance {


### PR DESCRIPTION
The instance favorite button did not work becuase in order for z-index to function properly you need to have a non-default position property for the object that has a z-index assigned to it. This fixes that issue.
