### PR TITLE
Transition to flexbox for question ordering

### DIFF
--- a/client/styles/global.scss
+++ b/client/styles/global.scss
@@ -64,16 +64,12 @@ a {
 }
 
 .container {
-  -webkit-column-width: 18em;
-  -moz-column-width: 18em;
-  column-width: 18em;
-
-	// -webkit-columns: 4 16em;
-	// -moz-columns: 4 16em;
-	// columns: 4 16em;
-  column-gap: 1em;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: stretch;
   margin: 0;
-	padding: 0 0 70px 0;
+	padding: 0 0 4em 0;
 }
 
 .formcontainer {
@@ -423,8 +419,8 @@ a {
 }
 
 .instance-wrapper {
-  display: inline-block;
-  width: 100%;
+  width: 22em;
+  margin: 0 0.5em;
   cursor: auto;
 
   &, div, span, a {

--- a/client/views/footer/footer.scss
+++ b/client/views/footer/footer.scss
@@ -5,6 +5,7 @@ $footer-bg-color: #293340;
 	right: 0;
 	bottom: 0;
 	position: absolute;
+  text-align: center;
 	background-color: $footer-bg-color;
   padding-top: 20px;
 	padding-bottom: 20px;

--- a/client/views/helpers/chunks/question_div/question_div.scss
+++ b/client/views/helpers/chunks/question_div/question_div.scss
@@ -5,9 +5,10 @@ $hidden-question-color: #FF0000;
 $popular-question-color: #f1c40f;
 
 .question-wrapper {
-  display: inline-block;
-  width: 100%;
+  display: flex;
+  width: 22em;
   cursor: auto;
+  margin: 0 0.5em;
 
   &, div, span, a {
     -webkit-column-break-inside: avoid;
@@ -23,6 +24,7 @@ $popular-question-color: #f1c40f;
 	padding: 8px 12px;
   margin-bottom: 12px;
   border-radius: $border-radius;
+  width: 22em;
 
   .image-icon {
     width: 14px;

--- a/client/views/list/list.html
+++ b/client/views/list/list.html
@@ -1,5 +1,6 @@
 <template name="list">
 	<div class="wrapper" id="main-wrapper">
+
 		{{> nav list=true title=tablename }}
 		<div class="description"><p><strong>Description:</strong> {{{description}}}</p></div>
 		<div id="hiddenName">{{tablename}}</div>
@@ -32,13 +33,14 @@
 				<p>Click and drag two questions together to combine.</p>
 			</div>
 		{{/if}}
+		{{#if hasChanges}}<div class="new-posts">Download New Posts</div>{{/if}}
     <div class="masonary-wrapper">
   		<div class="container">
   			{{#each question}}
   				{{> question_div}}
   			{{/each}}
   		</div>
-		</div>
+	</div>
 		{{> footer}}
 	</div>
 </template>


### PR DESCRIPTION
- Emulates old question ordering behavior by using flexbox
- Question ordering is now left to right.
- Boxes now stretch to fit largest sized box in its row.
- Moved from percentage width boxes to em
- Centered text in footer.
