### PR TITLE
Make rename/delete buttons work in the instance div + css improvements

### DIFF
--- a/client/styles/global.scss
+++ b/client/styles/global.scss
@@ -430,19 +430,6 @@ a {
   }
 }
 
-.instance {
-	&:hover {
-		.superadminrenamebutton {
-			border: 2px solid #999999;
-			color: #999999;
-		}
-
-		.superadmindeletebutton {
-			border: 2px solid #999999;
-			color: #999999;
-		}
-	}
-}
 
 .plusbutton {
 	display: inline-block;

--- a/client/views/helpers/chunks/instance_div/instance_div.html
+++ b/client/views/helpers/chunks/instance_div/instance_div.html
@@ -1,5 +1,5 @@
 <template name="instance_div">
-  <div class="instance-wrapper" title="Open instance">
+  <div class="instance-wrapper">
     <div id="{{_id}}" class="instance {{#if isFavorite}}favorite-instance {{else}} {{#if today}}today-instance{{/if}} {{#if week}}week-instance{{/if}} {{#if month}}month-instance{{/if}} {{/if}}">
       {{#if currentUser}}
         <div>
@@ -17,26 +17,26 @@
           <span class="favoritebutton {{#if isFavorite}}buttonFavorite{{/if}}" id="{{_id}}" title="{{#if isFavorite}}Remove from favorites{{else}}Add to favorites{{/if}}"></span>
         </div>
       {{/if}}
+      <a href="/list/{{slug}}" title="Open instance">
       <p class="instancename">
-        <a class="divLink" href="/list/{{slug}}"></a>{{tablename}}
+        {{tablename}}
       </p>
       <div class="descriptioncontainer">
         <span class="instancedescription">
   				{{description}}
   			</span>
       </div>
+      </a>
       <div class="instance-bottom">
         <span class="posted-by-text">posted by</span> <span class="postername">{{author}}</span>
-        <span class="time"> {{time_format lasttouch}}</span>
+        <span class="time" title="{{date_format lasttouch}}"> {{time_format lasttouch}}</span>
       {{#if superadmin}}
         <div class="adminbottom">
-          <!--<a class="hideQuestion" id="{{_id}}">Hide</a>
-  				<a href="{{modifylink}}">Modify</a>-->
           <div class="superadminrenamebutton" id="{{_id}}">
-            Rename
+            <i class="fa fa-pencil-square"></i> Rename
           </div>
           <div class="superadmindeletebutton" id="{{_id}}">
-            Delete
+            <i class="fa fa-trash"></i> Delete
           </div>
         </div>
       {{/if}}

--- a/client/views/helpers/chunks/instance_div/instance_div.js
+++ b/client/views/helpers/chunks/instance_div/instance_div.js
@@ -4,5 +4,8 @@ Template.instance_div.helpers ({
 	},
 	time_format: function(lasttouch){
 		return moment(lasttouch).fromNow(true);
+	},
+	date_format: function(lasttouch){
+		return moment(lasttouch).format('LLL');
 	}
 });

--- a/client/views/helpers/chunks/instance_div/instance_div.scss
+++ b/client/views/helpers/chunks/instance_div/instance_div.scss
@@ -3,6 +3,27 @@
 	background-image: url('/heart_filled.png') !important;
 }
 
+.adminbottom{
+	background-color: #eee;
+	padding: 0.2em;
+	padding-left: 0.4em;
+	padding-right: 0.4em;
+	border-radius: 5px;
+	margin-top: 0.3em;
+}
+
+.adminbottom div{
+	text-transform: uppercase;
+	font-weight: bold;
+	color: #2c3e50;
+	font-size: 0.85em;
+	cursor: pointer;
+	transition-duration: 0.3s;
+	&:hover{
+		opacity: 0.7;
+	}
+}
+
 
 .instancedescription {
 	font-weight: 300;


### PR DESCRIPTION
Super Admin buttons in the instance div (home page) didn't work, so these changes should get them to behave as expected (plus, view exact time instance was last edited by hovering over the "x ago" text in the instance div).