### PR TITLE
[#13876] Adjust position of error in creation div

### DIFF
--- a/client/styles/global.scss
+++ b/client/styles/global.scss
@@ -396,6 +396,7 @@ a {
 #checkarea2 {
 	width: 180px;
 	float: left;
+	padding-top: 13px;
 }
 
 #toparea {

--- a/client/views/create/create.js
+++ b/client/views/create/create.js
@@ -159,6 +159,6 @@ function showCreateError(reason) {
 		document.getElementById("buttonarea").disabled = false;
 	}
 	var parentNode = document.getElementById("creatediv");
-	var nextNode = document.getElementById("instancebottominputcontainer");
+	var nextNode = document.getElementById("instancetopinputcontainer");
 	currentError = Blaze.renderWithData(Template.form_error, reason, parentNode, nextNode);
 }


### PR DESCRIPTION
- Adjust position of error to conform to design, while keeping the red.
- Adjust position of the "Allow anonymous" checkbox to align with "Advanced options".