### PR TITLE
[#13933, #13875] Fix issues with mobile navbar + Stylize description

### DIFF
--- a/client/styles/responsive.scss
+++ b/client/styles/responsive.scss
@@ -124,10 +124,11 @@ $screen-md-max:              ($screen-lg-min - 1);
 
 // for xs and sm
 
-@media (max-width: $screen-xs-max) {
+@media (max-width: $screen-sm-max) {
   #nav {
     padding-left: 0;
-    padding-right: 0;
+    padding-right: 0.5em;
+    justify-content: flex-end;
   }
 
   #navButtons {

--- a/client/views/helpers/nav/nav.html
+++ b/client/views/helpers/nav/nav.html
@@ -1,5 +1,8 @@
 <template name="nav">
   <div id="nav-wrapper">
+    <div class="mobiletitle hidden-md hidden-lg">
+      <h1 class="hidden-md hidden-lg">{{this.title}}</h1>
+    </div>
   	<div id="nav" class="{{#if this.list}}{{#if currentUser}}loggedinlistbanner{{else}}loggedoutlistbanner{{/if}}{{else}}homebanner{{/if}}">
   		<h1 id="tablename" class="hidden-xs hidden-sm">
   			{{this.title}}
@@ -18,6 +21,7 @@
     				<li><a id="navShare" class="link" title="Share"><i class="fa fa-share-alt-square"></i></a></li>
     			{{/if}}
     		</ul>
+        <div>
         <ul id="navoptions">
     		{{#if currentUser}}
     			{{#if this.list}}
@@ -41,6 +45,7 @@
     			<li><a id="navRegister" class="link">Sign up</a></li>
     		{{/if}}
         </ul>
+        </div>
   	</div>
     <div id="mobile-nav">
       <input id="mobile-searchbar" class="{{#if this.list}}listsearchbar{{else}}homesearchbar{{/if}} hidden-md hidden-lg searchbar" type="text" placeholder="Search...">

--- a/client/views/helpers/nav/nav.html
+++ b/client/views/helpers/nav/nav.html
@@ -2,6 +2,9 @@
   <div id="nav-wrapper">
     <div class="mobiletitle hidden-md hidden-lg">
       <h1 class="hidden-md hidden-lg">{{this.title}}</h1>
+      {{#if currentUser}}
+          <a class="mobileprofile" id="navProfile hidden-md hidden-lg">Hi, {{currentUser.profile.name}}!</a>
+      {{/if}}
     </div>
   	<div id="nav" class="{{#if this.list}}{{#if currentUser}}loggedinlistbanner{{else}}loggedoutlistbanner{{/if}}{{else}}homebanner{{/if}}">
   		<h1 id="tablename" class="hidden-xs hidden-sm">
@@ -10,11 +13,7 @@
   		<input id="searchbar" class="{{#if this.list}}listsearchbar{{else}}homesearchbar{{/if}} hidden-xs hidden-sm searchbar" type="text" placeholder="Search...">
     		<ul id="navbuttons">
           {{#if currentUser}}
-            {{#if this.list}}
             <li class="no-bg hidden-xs hidden-sm"><a id="navProfile">Hi, {{currentUser.profile.name}}!</a></li>
-            {{ else }}
-            <li class="no-bg"><a id="navProfile">Hi, {{currentUser.profile.name}}!</a></li>
-            {{/if}}
           {{/if}}
     			{{#if this.list}}
             <li><a id="navHome" class="link" title="Home"><i class="fa fa-home"></i></a></li>

--- a/client/views/helpers/nav/nav.scss
+++ b/client/views/helpers/nav/nav.scss
@@ -6,7 +6,11 @@ $screen-md: 992px;
 $screen-sm-max: ($screen-md - 1);
 
 
-
+.mobileprofile{
+	color: $nav-text-color;
+	font-weight: 600;
+	font-size: 1.1em;
+}
 .mobiletitle{
 	background: $nav-bg-color;
   	color: $nav-text-color;

--- a/client/views/helpers/nav/nav.scss
+++ b/client/views/helpers/nav/nav.scss
@@ -2,7 +2,21 @@ $nav-bg-color: #293340;
 $nav-text-color: #eee;
 $screen-sm: 768px;
 $screen-xs: 480px;
+$screen-md: 992px;
+$screen-sm-max: ($screen-md - 1);
 
+
+
+.mobiletitle{
+	background: $nav-bg-color;
+  	color: $nav-text-color;
+  	padding-top: 1em;
+  	text-align: center;
+  	h1{
+  		margin: 0 !important;
+  		font-size: 22px;
+  	}
+}
 #nav {
 	background: $nav-bg-color;
   	color: $nav-text-color;
@@ -60,7 +74,7 @@ $screen-xs: 480px;
 }
 
 #mobile-nav {
-	@media screen and (max-width: $screen-sm){
+	@media screen and (max-width: $screen-sm-max){
 		background-color: $nav-bg-color;
 		padding: 0.5em;
 	}

--- a/client/views/list/list.html
+++ b/client/views/list/list.html
@@ -2,7 +2,7 @@
 	<div class="wrapper" id="main-wrapper">
 
 		{{> nav list=true title=tablename admin=admin }}
-		<div class="description"><p><strong>Description:</strong> {{{description}}}</p></div>
+		<div class="description" title="Description">{{{description}}}</div>
 		<div id="hiddenName">{{tablename}}</div>
 		<div id="navUnPresent">Unhide</div>
 		{{#if admin}}

--- a/client/views/list/list.scss
+++ b/client/views/list/list.scss
@@ -16,11 +16,15 @@ $screen-sm: 768px;
 
 .description {
 	display: block;
-	margin: 0 auto;
-	padding: 0 20px;
-	color: #999999;
+	margin-bottom: 1em;
+	padding: 0.5em;
+	color: #293340;
 	font-weight: 600;
+	font-size: 1.3em;
+	text-align: center;
+	background-color: #bdc3c7;
 	overflow-wrap: break-word;
+
 }
 
 #questiondiv {


### PR DESCRIPTION
- Fix search bar displaying at full width in thinner screens.
- Display "Hi, USERNAME" in all screen sizes/pages.
- Float icons to right in smaller screens.
- Display title in smaller screens.
- Center and visually separate description from the rest of the instance elements (+ remove "Description").