### PR TITLE
Resolves #102 Modified the error message displayed while creating a new instance

### DIFF
--- a/client/views/create/create.js
+++ b/client/views/create/create.js
@@ -119,7 +119,8 @@ Template.create.events({
       if (typeof result === 'object') {
         // Store an object of the error names and codes
         const errorCodes = {
-          tablename: 'Please enter a valid instance name using only letters and numbers, no spaces.',
+          // tablename: 'Please enter a valid instance name using only letters and numbers, no spaces.',
+          tablename: 'Please enter a valid instance name using 4 to 30 alphanumeric characters without spaces.',
           threshold: "Please enter a valid # of 'featured' questions using the drop down menu.",
           new_length: "Please enter a valid value using the 'new questions' drop down menu.",
           stale_length: "Please enter a valid value using the 'old questions' drop down menu.",


### PR DESCRIPTION
I have modified the error message which is displayed while creating a new instance. The error message now clearly specifies the valid length of the instance name. If a user makes instance with name of length 3, then he/she will realise the mistake through the error message and rectify it.

Pic of the old error message
![a](https://user-images.githubusercontent.com/32926581/54717172-912ab080-4b7d-11e9-9143-9d855eac7364.png)


Pic of the modified error message
![b](https://user-images.githubusercontent.com/32926581/54717195-a30c5380-4b7d-11e9-9bf7-8db97f5668d1.png)

