### PR TITLE
Added new regular expression to accept spaces in instance name

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -11,7 +11,7 @@ const Schemas = {};
 Schemas.Instance = new SimpleSchema({
   tablename: {
     type: String,
-    regEx: /^[a-zA-Z0-9]{4,30}$/,
+    regEx: /^[0-9a-zA-Z \b]{4,30}$/ // Regular expression to accept string containing at least one letter and optionally is followed by number or space or any other letter.
   },
   threshold: {
     type: Number,
@@ -81,7 +81,7 @@ Schemas.Question = new SimpleSchema({
   },
   tablename: {
     type: String,
-    regEx: /^[a-zA-Z0-9]{4,30}$/,
+    regEx: /^[0-9a-zA-Z \b]{4,30}$/ // Regular expression to accept string containing at least one letter and optionally is followed by number or space or any other letter.
   },
   text: {
     type: String,


### PR DESCRIPTION
The pull request is implementation for the feature listed in issue #14792 and #12582. The instance name can be made by using space between words or digits but no other special character is allowed. The corresponding regular expression was updated to update the table name accepting regular expression.

![image](https://user-images.githubusercontent.com/29747452/59162297-0c13bf80-8b0c-11e9-9b49-ddba0d7255c0.png)
