### PR TITLE
Added close button to admin interface

### DIFF
--- a/client/views/list/list.html
+++ b/client/views/list/list.html
@@ -10,7 +10,14 @@
 		</div>
 		{{#if admin}}
 			<div class="admincontainer">
-				<h2>Admin Interface</h2>
+				<div class="admin-nav">
+					<div>
+						<h2>Admin Interface</h2>
+					</div>
+					<div>
+						{{> close_button}}
+					</div>
+				</div>
 				<p>Click and drag two questions together to combine.</p>
 				<ul id="admin-button-list" data-table-id="{{_id}}">
 					<li id="unhidebutton">Unhide all</li>

--- a/client/views/list/list.html
+++ b/client/views/list/list.html
@@ -11,12 +11,8 @@
 		{{#if admin}}
 			<div class="admincontainer">
 				<div class="admin-nav">
-					<div>
-						<h2>Admin Interface</h2>
-					</div>
-					<div>
-						{{> close_button}}
-					</div>
+					<div><h2>Admin Interface</h2></div>
+					<div>{{> close_button}}</div>
 				</div>
 				<p>Click and drag two questions together to combine.</p>
 				<ul id="admin-button-list" data-table-id="{{_id}}">

--- a/client/views/list/list.js
+++ b/client/views/list/list.js
@@ -196,7 +196,7 @@ Template.list.onCreated(function () {
   };
 
   this.updateInPlace = (questions) => {
-    questions.forEach(question => 
+    questions.forEach(question =>
       this.visibleQuestions.update({ _id: question._id }, { $set: { state: question.state } })
     );
   };
@@ -270,7 +270,7 @@ Template.list.helpers({
     if (this.state !== 'disabled') return true;
 
     if (isPresenting === true) return false;
-    
+
     let tableAdmin = false;
     let tableMod = false;
     let instance = Instances.findOne({ _id: this.instanceid });
@@ -693,5 +693,10 @@ Template.list.events({
   'blur .replyarea': function(event, template) {
     Template.instance().state.set('typing', false);
   },
+  "click .closecontainer": function(event, template) {
+    document
+      .getElementsByClassName("admincontainer")[0]
+      .setAttribute("style", "display: none;");
+  }
 });
 /* eslint-enable func-names, no-unused-vars */

--- a/client/views/list/list.js
+++ b/client/views/list/list.js
@@ -693,10 +693,8 @@ Template.list.events({
   'blur .replyarea': function(event, template) {
     Template.instance().state.set('typing', false);
   },
-  "click .closecontainer": function(event, template) {
-    document
-      .getElementsByClassName("admincontainer")[0]
-      .setAttribute("style", "display: none;");
+  'click .closecontainer': function(event, template) {
+    $('.admincontainer').css('display', 'none'); // Updated the css on the click event of close button in admin interface card
   }
 });
 /* eslint-enable func-names, no-unused-vars */

--- a/client/views/list/list.js
+++ b/client/views/list/list.js
@@ -694,7 +694,7 @@ Template.list.events({
     Template.instance().state.set('typing', false);
   },
   'click .closecontainer': function(event, template) {
-    $('.admincontainer').css('display', 'none'); // Updated the css on the click event of close button in admin interface card
+    $('.admincontainer').css('display', 'none');
   }
 });
 /* eslint-enable func-names, no-unused-vars */

--- a/client/views/list/list.scss
+++ b/client/views/list/list.scss
@@ -248,3 +248,13 @@ $screen-sm: 768px;
 		padding-bottom: 2px;
 	}
 }
+
+.admin-nav {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+}
+
+.closecontainer {
+	margin-top: 0;
+}


### PR DESCRIPTION
The pull request is implementation for the feature listed in issue #16370. Now when the "Admin Interface" card is displayed there is a close button implemented in the top right corner of the card to give the user a more intuitive way to understand on how to close the card. After the addition of button on the upper right of the card to close it is more intuitive and existing functionality with the Admin Button acting as a toggle for the card is staying

Here is a screenshot attached below

![image](https://user-images.githubusercontent.com/29747452/59162854-c825b800-8b15-11e9-83fe-9dc94a2eec2d.png)
