### PR TITLE
Added error functionality while addition of admin as moderator to an instance

### DIFF
--- a/client/views/add/add.js
+++ b/client/views/add/add.js
@@ -73,7 +73,7 @@ Template.add.events({
   'click #modsdonebutton': function (event, template) {
     const modBoxes = document.getElementsByClassName('modbox');
     const modBoxesArray = Array.from(modBoxes);
-    const modEmails = modBoxesArray.map(b => b.value);  
+    const modEmails = modBoxesArray.map(b => b.value);
     const occurrences = modEmails.filter(val => val !== "").length;
     if (occurrences > 4) {
       showModsError('You can only assign 4 moderators per instance.');
@@ -92,11 +92,15 @@ Template.add.events({
     }
     Meteor.call('addMods', mods, template.data._id, (error, result) => {
       // If the result is an object, there was an error
-      if (typeof result === 'object') {
+      if (typeof result === 'object' && result.length > 0) {
         // Alert the error
         for (let i = 0; i < result.length; i++) {
           if (result[i].name === 'moderators') {
             showModsError('You can only assign 4 moderators per instance.');
+            return false;
+          }
+          if(result[i].name === 'owner') { // Check is the server returned error corresponding to the addition of owner as moderator
+            showModsError('You cannot add owner of the instance as moderator'); // Display the error message
             return false;
           }
         }

--- a/client/views/add/add.js
+++ b/client/views/add/add.js
@@ -99,8 +99,9 @@ Template.add.events({
             showModsError('You can only assign 4 moderators per instance.');
             return false;
           }
-          if(result[i].name === 'owner') { // Check is the server returned error corresponding to the addition of owner as moderator
-            showModsError('You cannot add owner of the instance as moderator'); // Display the error message
+          // Check is the server returned error corresponding to the addition of owner as moderator
+          if(result[i].name === 'owner') {
+            showModsError(`${result[i].value} is already an owner of the instance and has the privileges of a moderator.`); // Display the error message
             return false;
           }
         }

--- a/client/views/add/add.js
+++ b/client/views/add/add.js
@@ -101,7 +101,8 @@ Template.add.events({
           }
           // Check is the server returned error corresponding to the addition of owner as moderator
           if(result[i].name === 'owner') {
-            showModsError(`${result[i].value} is already an owner of the instance and has the privileges of a moderator.`); // Display the error message
+            // Display the error message
+            showModsError(`${result[i].value} is already an owner of the instance and has the privileges of a moderator.`);
             return false;
           }
         }

--- a/server/methods.js
+++ b/server/methods.js
@@ -270,7 +270,13 @@ Meteor.methods({
       const instance = Instances.findOne({
         _id: instanceid,
       });
+      var found = mods.find(function(element){
+        return element === instance.admin;
+      });
       if (email === instance.admin) {
+        if(typeof found !== 'undefined') {
+            return [{name: 'owner', type: 'Invalid candidate for moderator', value: instance.admin}];
+        }
         Instances.update({
           _id: instanceid,
         }, {

--- a/server/methods.js
+++ b/server/methods.js
@@ -270,12 +270,12 @@ Meteor.methods({
       const instance = Instances.findOne({
         _id: instanceid,
       });
-      var found = mods.find(function(element){
+      var found = mods.find(function(element) {
         return element === instance.admin;
       });
       if (email === instance.admin) {
         if(typeof found !== 'undefined') {
-            return [{name: 'owner', type: 'Invalid candidate for moderator', value: instance.admin}];
+            return [{name: 'owner', type: 'An invalid candidate for a moderator', value: instance.admin}];
         }
         Instances.update({
           _id: instanceid,


### PR DESCRIPTION
The pull request is implementation for the feature listed in issue #15448. Earlier Admin of an instance can be added as a moderator too which was erroneous. Now, this issue is resolved. Now one cannot add admin of an instance as a moderator.
![image](https://user-images.githubusercontent.com/29747452/59378281-9b6ddc80-8d71-11e9-855d-1d6d270ae7f6.png)
