### PR TITLE
Proper verification and error message added for invalid moderator emails

### DIFF
--- a/client/views/create/create.js
+++ b/client/views/create/create.js
@@ -53,7 +53,7 @@ Template.create.events({
       $('.instancemodsinput').removeClass('lastmodinput');
       $('.plusbuttoncontainer').removeClass('lastmodinput');
       $('.instancemodsplus').remove();
-      $('<input class="instancemodsinput lastmodinput" type="email" placeholder="Moderator email..."><div class="emptyinputspacer lastinputspacer"><div class="plusbuttoncontainer"><div class="instancemodsplus">+</div></div></div>').insertAfter('.lastinputspacer').last(); // Updated the input type to email for perfect validation
+      $('<input class="instancemodsinput lastmodinput" type="email" placeholder="Moderator email..."><div class="emptyinputspacer lastinputspacer"><div class="plusbuttoncontainer"><div class="instancemodsplus">+</div></div></div>').insertAfter('.lastinputspacer').last();
       $('.lastinputspacer').first().removeClass('lastinputspacer');
       $('#instancebottominputcontainer').height((index, height) => (height + 50));
     } else {
@@ -157,11 +157,14 @@ Template.create.events({
       last.previousSibling.focus();
     }
   },
-  'change .instancemodsinput': function(event, template) { // Function to be triggered on change event of the moderator email input
-    if(!event.target.checkValidity()) { // If the input is not valid show error
+  'change .instancemodsinput': function(event, template) {
+    // Function to be triggered on change event of the moderator email input
+    if(!event.target.checkValidity()) {
+      // If the input is not valid show error
       showCreateError(event.target.value + ' is not a valid email.');
-    } else { // If input is valid remove errors
-      $(".error").css("display", "none");
+    } else {
+      // If input is valid remove errors
+      $('.error').css('display', 'none');
     }
   }
 });

--- a/client/views/create/create.js
+++ b/client/views/create/create.js
@@ -53,7 +53,7 @@ Template.create.events({
       $('.instancemodsinput').removeClass('lastmodinput');
       $('.plusbuttoncontainer').removeClass('lastmodinput');
       $('.instancemodsplus').remove();
-      $('<input class="instancemodsinput lastmodinput" type="text" placeholder="Moderator email..."><div class="emptyinputspacer lastinputspacer"><div class="plusbuttoncontainer"><div class="instancemodsplus">+</div></div></div>').insertAfter('.lastinputspacer').last();
+      $('<input class="instancemodsinput lastmodinput" type="email" placeholder="Moderator email..."><div class="emptyinputspacer lastinputspacer"><div class="plusbuttoncontainer"><div class="instancemodsplus">+</div></div></div>').insertAfter('.lastinputspacer').last(); // Updated the input type to email for perfect validation
       $('.lastinputspacer').first().removeClass('lastinputspacer');
       $('#instancebottominputcontainer').height((index, height) => (height + 50));
     } else {
@@ -157,7 +157,13 @@ Template.create.events({
       last.previousSibling.focus();
     }
   },
+  'change .instancemodsinput': function(event, template) { // Function to be triggered on change event of the moderator email input
+    if(!event.target.checkValidity()) { // If the input is not valid show error
+      showCreateError(event.target.value + ' is not a valid email.');
+    } else { // If input is valid remove errors
+      $(".error").css("display", "none");
+    }
+  }
 });
 
 /* eslint-enable func-names, no-unused-vars */
-


### PR DESCRIPTION
The pull request is implementation for the feature listed in issue #15450. Earlier when adding moderators while making the instance, only the first moderator email field was getting verified and prompts error when the invalid email is entered in it. All the other moderator email fields (if the admin adds more than 1) prompts the error but it only showed the error box and no message.
Now there is the following updates:
1) Now all the emails entered as the moderator are getting verified.
2) When the input field for moderator email changes then also the error message is displayed along when clicking the create instance button.

![image](https://user-images.githubusercontent.com/29747452/59402219-0db6df00-8dbb-11e9-890e-cee10e53f1e3.png)
![image](https://user-images.githubusercontent.com/29747452/59402229-13acc000-8dbb-11e9-844b-7a83267bcd19.png)
