### PR TITLE
Feature remove icon in add moderator

### DIFF
--- a/client/styles/global.scss
+++ b/client/styles/global.scss
@@ -473,6 +473,22 @@ a {
 	font-weight: 600;
 }
 
+.minusbutton {
+	display: inline-block;
+	width: 25px;
+	height: 25px;
+	border-radius: 2px;
+	cursor: pointer;
+	background-color: red;
+	margin-top: 15px;
+	color: white;
+	font-size: 18px;
+	padding-top: 0px;
+	text-align: center;
+	margin-left: 10px;
+	font-weight: 600;
+}
+
 .plusbuttoncontainer {
 	width: 51px;
 	height: 50px;
@@ -481,5 +497,3 @@ a {
 #recent {
 	padding-bottom: 45px;
 }
-
-

--- a/client/views/add/add.html
+++ b/client/views/add/add.html
@@ -22,7 +22,7 @@
 			<div class="modline">
 				<input class="modbox newmod" style="float:left" type="text" maxlength="45" />
 				<div class="minusbutton" style="display: none;">
-					x
+					-
 				</div>
 				<div class="plusbutton">
 					+

--- a/client/views/add/add.html
+++ b/client/views/add/add.html
@@ -1,29 +1,35 @@
 <template name="add">
-	<div id="darker">
-	</div>
+	<div id="darker"></div>
 	<div class="formcontainer modformcontainer">
 		{{> close_button}}
+
 		<h1 class="formtitle">Add Moderators</h1>
 		<div class="modaltopmessage">
 			Press the red "x" to remove moderators. Type in new emails and press "+" for more. Hit "done" once finished.
 		</div>
 		<div class="inputcontainer" style="text-align: center;">
 			{{#each mods}}
-				<div class="modline">
-                    <input class="modbox" disabled="disabled" style="float:left" type="text" maxlength="45" value="{{this}}"/>
-					<div class="removebutton" data-email="{{this}}">
+
+			<div class="modline">
+				<input class="modbox" disabled="disabled" style="float:left" type="text" maxlength="45" value="{{this}}"/>
+				<div class="removebutton" data-email="{{this}}">
 						x
-					</div>
 				</div>
+			</div>
 			{{/each}}
 			{{#each loop newMod}}
+
 			<div class="modline">
-                <input class="modbox newmod" style="float:left" type="text" maxlength="45" />
+				<input class="modbox newmod" style="float:left" type="text" maxlength="45" />
+				<div class="minusbutton" style="display: none;">
+					x
+				</div>
 				<div class="plusbutton">
 					+
 				</div>
 			</div>
 			{{/each}}
+
 			<div id="modsdonebutton">
 				Done
 			</div>

--- a/client/views/add/add.js
+++ b/client/views/add/add.js
@@ -60,10 +60,15 @@ Template.add.events({
       return false;
     }
     const buttons = row.getElementsByClassName('plusbutton');
+    const minusButton = row.getElementsByClassName('minusbutton');
     for (let i = 0; i < buttons.length; i++) {
       buttons[i].style.display = 'none';
+      minusButton[i].style.display = 'inline-block';
     }
     template.numberOfNewMods.set(template.numberOfNewMods.get() + 1);
+  },
+  'click .minusbutton': function(event, template) {
+    event.currentTarget.parentElement.remove();
   },
   'click .removebutton': function (event, template) {
     const mod = $(event.currentTarget).data('email');
@@ -73,7 +78,7 @@ Template.add.events({
   'click #modsdonebutton': function (event, template) {
     const modBoxes = document.getElementsByClassName('modbox');
     const modBoxesArray = Array.from(modBoxes);
-    const modEmails = modBoxesArray.map(b => b.value);  
+    const modEmails = modBoxesArray.map(b => b.value);
     const occurrences = modEmails.filter(val => val !== "").length;
     if (occurrences > 4) {
       showModsError('You can only assign 4 moderators per instance.');


### PR DESCRIPTION
The pull request is implementation for the feature listed in issue #16611. Implementation of edit logic for backend has been updated. When we use the edit moderator button and then click the "+" icon, there is an "-" icon added that immediately comes up for deleting that row.

![image](https://user-images.githubusercontent.com/29747452/61484511-b65ced80-a9bc-11e9-9267-0167af3f9bf2.png)
