### PR TITLE
Removed the hard limit of 4 moderators

### DIFF
--- a/client/views/add/add.js
+++ b/client/views/add/add.js
@@ -55,10 +55,6 @@ Template.add.events({
       showModsError('Email ID was already added as a moderator.');
       return false;
     }
-    if (modBoxes.length >= 4) {
-      showModsError("You've reached max of 4 moderators.");
-      return false;
-    }
     const buttons = row.getElementsByClassName('plusbutton');
     for (let i = 0; i < buttons.length; i++) {
       buttons[i].style.display = 'none';
@@ -75,10 +71,6 @@ Template.add.events({
     const modBoxesArray = Array.from(modBoxes);
     const modEmails = modBoxesArray.map(b => b.value);
     const occurrences = modEmails.filter(val => val !== "").length;
-    if (occurrences > 4) {
-      showModsError('You can only assign 4 moderators per instance.');
-      return false;
-    }
     if (checkPrevMod(modBoxes) === false) {
       showModsError('Email ID was already added as a moderator.');
       return false;
@@ -95,10 +87,6 @@ Template.add.events({
       if (typeof result === 'object' && result.length > 0) {
         // Alert the error
         for (let i = 0; i < result.length; i++) {
-          if (result[i].name === 'moderators') {
-            showModsError('You can only assign 4 moderators per instance.');
-            return false;
-          }
           // Check is the server returned error corresponding to the addition of owner as moderator
           if(result[i].name === 'owner') {
             // Display the error message

--- a/client/views/create/create.js
+++ b/client/views/create/create.js
@@ -49,17 +49,12 @@ Template.create.events({
   },
   'click .instancemodsplus': function (event, template) {
     const spacers = document.getElementsByClassName('emptyinputspacer');
-    if (spacers.length < 4) {
-      $('.instancemodsinput').removeClass('lastmodinput');
-      $('.plusbuttoncontainer').removeClass('lastmodinput');
-      $('.instancemodsplus').remove();
-      $('<input class="instancemodsinput lastmodinput" type="email" placeholder="Moderator email..."><div class="emptyinputspacer lastinputspacer"><div class="plusbuttoncontainer"><div class="instancemodsplus">+</div></div></div>').insertAfter('.lastinputspacer').last();
-      $('.lastinputspacer').first().removeClass('lastinputspacer');
-      $('#instancebottominputcontainer').height((index, height) => (height + 50));
-    } else {
-      showCreateError("You've reached the maximum # of moderators (4).");
-      return false;
-    }
+    $('.instancemodsinput').removeClass('lastmodinput');
+    $('.plusbuttoncontainer').removeClass('lastmodinput');
+    $('.instancemodsplus').remove();
+    $('<input class="instancemodsinput lastmodinput" type="email" placeholder="Moderator email..."><div class="emptyinputspacer lastinputspacer"><div class="plusbuttoncontainer"><div class="instancemodsplus">+</div></div></div>').insertAfter('.lastinputspacer').last();
+    $('.lastinputspacer').first().removeClass('lastinputspacer');
+    $('#instancebottominputcontainer').height((index, height) => (height + 50));
   },
   'click #buttonarea': function (event, template) {
     if (!Meteor.user()) {
@@ -128,8 +123,7 @@ Template.create.events({
           threshold: "Please enter a valid # of 'featured' questions using the drop down menu.",
           new_length: "Please enter a valid value using the 'new questions' drop down menu.",
           stale_length: "Please enter a valid value using the 'old questions' drop down menu.",
-          description: 'Please enter a valid description under 255 characters.',
-          moderators: 'You have entered too many moderators. Please try again.',
+          description: 'Please enter a valid description under 255 characters.'
         };
         // Alert the error
         showCreateError(errorCodes[result[0].name]);

--- a/lib/common.js
+++ b/lib/common.js
@@ -39,8 +39,7 @@ Schemas.Instance = new SimpleSchema({
   },
   moderators: {
     type: Array,
-    optional: true,
-    maxCount: 4,
+    optional: true
   },
   'moderators.$': {
     type: String,


### PR DESCRIPTION
The pull request is implementation for the feature listed in issue #14788. We currently only allow one admin or owner of an instance and limit mods with a max of 4. The limit of the mods has been removed. Now one can add any number of moderators for an instance either during creation or update.
![image](https://user-images.githubusercontent.com/29747452/61583593-e2f93c80-ab57-11e9-938c-9611c75bb0c8.png)
